### PR TITLE
Fix gas issues when doing callbacks, add GAS_COMMONLY_CONSUMED

### DIFF
--- a/sputnikdao2/src/proposals.rs
+++ b/sputnikdao2/src/proposals.rs
@@ -7,7 +7,8 @@ use near_sdk::{ext_contract, log, AccountId, Balance, Gas, PromiseOrValue, Promi
 
 use crate::policy::UserInfo;
 use crate::types::{
-    upgrade_remote, upgrade_self, Action, Config, GAS_FOR_FT_TRANSFER, ONE_YOCTO_NEAR,
+    upgrade_remote, upgrade_self, Action, Config, GAS_COMMONLY_CONSUMED, GAS_FOR_FT_TRANSFER,
+    ONE_YOCTO_NEAR,
 };
 use crate::*;
 
@@ -353,7 +354,7 @@ impl Contract {
                         msg,
                         env::current_account_id(),
                         0,
-                        GAS_FOR_FT_TRANSFER,
+                        env::prepaid_gas() - GAS_COMMONLY_CONSUMED,
                     ))
                     .into()
                 }
@@ -426,7 +427,7 @@ impl Contract {
                 msg,
                 env::current_account_id(),
                 0,
-                GAS_FOR_FT_TRANSFER,
+                env::prepaid_gas() - GAS_COMMONLY_CONSUMED,
             ))
             .into()
         }

--- a/sputnikdao2/src/types.rs
+++ b/sputnikdao2/src/types.rs
@@ -8,6 +8,7 @@ pub const ONE_YOCTO_NEAR: Balance = 1;
 
 /// Gas for single ft_transfer call.
 pub const GAS_FOR_FT_TRANSFER: Gas = Gas(10_000_000_000_000);
+pub const GAS_COMMONLY_CONSUMED: Gas = Gas(30_000_000_000_000);
 
 /// Gas for upgrading this contract on promise creation + deploying new contract.
 pub const GAS_FOR_UPGRADE_SELF_DEPLOY: Gas = Gas(30_000_000_000_000);


### PR DESCRIPTION
I was drilling into the issues with the simulation tests and wrote this bash script, feel free to try and modify the top part, declaring your own accounts. You can place this file in the `sputnikdao2` directory and run it.

```bash
#!/bin/sh
./build.sh
# Change these to your account ids
export CONTRACT_ID=sputnikdao2.mike.testnet
export FT_ID=ft.mike.testnet
export CONTRACT_PARENT=mike.testnet

# Redo account (if contract already exists)
near delete $CONTRACT_ID $CONTRACT_PARENT
near create-account $CONTRACT_ID --masterAccount $CONTRACT_PARENT
near delete $FT_ID $CONTRACT_PARENT
near create-account $FT_ID --masterAccount $CONTRACT_PARENT

# Set up
near deploy $CONTRACT_ID --wasmFile ~/near/sputnik-dao-contract/sputnikdao2/res/sputnikdao2.wasm
near deploy $FT_ID --wasmFile ~/near/sputnik-dao-contract/sputnikdao2/res/test_token.wasm --initFunction new --initArgs {}
near call $FT_ID mint '{"account_id": "'$CONTRACT_ID'", "amount": "100"}' --accountId $FT_ID

export COUNCIL='["'$CONTRACT_ID'"]'
near call $CONTRACT_ID new '{"config": {"name": "genesis2", "purpose": "test", "metadata": ""}, "policy": '$COUNCIL'}' --accountId $CONTRACT_ID

# Add proposal for a Transfer kind that pays out 19 NEAR
near call $CONTRACT_ID add_proposal '{"proposal": {"description": "test", "kind": {"Transfer": {"token_id": "'$FT_ID'", "receiver_id": "demo.testnet", "amount": "50"}}}}' --accountId $CONTRACT_ID --amount 1

echo before
near view $FT_ID ft_balance_of '{"account_id": "demo.testnet"}'

# approve (currently exceeding gas)
near call $CONTRACT_ID act_proposal '{"id": 0, "action": "VoteApprove"}' --accountId $CONTRACT_ID --gas 300000000000000

near view $CONTRACT_ID get_proposal '{"id": 0}'

echo after
near view $FT_ID ft_balance_of '{"account_id": "demo.testnet"}'
```

If you run this on the pull request here: https://github.com/near-daos/sputnik-dao-contract/pull/49, you'll see that there are gas exceeded errors.

The general pattern is to take the prepaid gas and subtract how much has been used by the contract. The issue is that during the callback process, we were only giving 10 teragas for the rest of the execution, which wasn't enough.

Secondary to this pull request I will point out that you're right about simulation tests not cutting it. I'll create an issue about that.